### PR TITLE
Fix/query net changes directly

### DIFF
--- a/namada-masp-dashboard/src/api/chain.ts
+++ b/namada-masp-dashboard/src/api/chain.ts
@@ -1,5 +1,5 @@
 import apiClient from "./apiClient";
-import { Token, Balance, AggregatesResponse } from "../types/token";
+import { Token, Balance, AggregatesResponse, ApiBalance } from "../types/token";
 import {
     MaspEpochResponse,
     MaspInflationResponse,
@@ -99,6 +99,8 @@ export interface TransformedTokenSupply {
 export interface MaspBalances {
     balances: Balance[];
 }
+
+export type ApiMaspBalances = ApiBalance[];
 
 export interface TransformedTokenAmounts {
     balances: Array<TransformedTokenAmount>;
@@ -245,6 +247,11 @@ export async function fetchMaspBalances(): Promise<MaspBalances> {
         `${indexerUrl}/api/v1/account/${MASP_ADDRESS}`,
     );
     return { balances: data };
+}
+
+export async function fetchMaspBalancesAtTime(timestamp: string): Promise<ApiMaspBalances> {
+    const { data } = await apiClient.get(`${apiUrl}/api/v1/masp/balances/all?time=${timestamp}`);
+    return data;
 }
 
 export async function fetchRewardTokens(): Promise<RewardTokensResponse> {

--- a/namada-masp-dashboard/src/components/assetTable/MetricsColumn.tsx
+++ b/namada-masp-dashboard/src/components/assetTable/MetricsColumn.tsx
@@ -34,6 +34,7 @@ function MetricsColumn({
             </div>
         );
     }
+    console.log(maspBalances)
 
     return (
         <div className="h-full">

--- a/namada-masp-dashboard/src/types/token.ts
+++ b/namada-masp-dashboard/src/types/token.ts
@@ -23,6 +23,11 @@ export interface Balance {
     minDenomAmount: string;
 }
 
+export interface ApiBalance {
+    token: string;
+    raw_amount: string;
+}
+
 // MASP aggregate data
 export interface FlowAggregate {
     tokenAddress: string;


### PR DESCRIPTION
now that we have a table for masp historical balances, we can calculate the net changes for 1d, 7d, 30d ago by querying the balances at that timestamp directly instead of calculating it indirectly from the masp aggregates data.

this shouldn't change the displayed values much or at all but lets us simplify the calculation and be more confident in its accuracy